### PR TITLE
Camera control and cam_gantry_playerFollow updates (cleaned)

### DIFF
--- a/scripts/cam_gantry_playerFollow.gd
+++ b/scripts/cam_gantry_playerFollow.gd
@@ -17,8 +17,8 @@ func _ready() -> void:
 	MgrPlayerSocket.get_player_one().ganty_thing = self
 
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _physics_process(delta: float) -> void:
+#also changed _physics_process to process here for jitter fix
+func _process(delta: float) -> void:
 	if thrall == null:
 		return
 	var desired_pos = thrall.global_position
@@ -29,15 +29,9 @@ func _physics_process(delta: float) -> void:
 		return
 	if velocity.length() > 10:
 		velocity = velocity.normalized() * 10
-		# NOTE - This is a hack, the velocity equation had a good feel too it, but went off the rails into the NaNosphere after a certain distance
-	#global_position = lerp(global_position, desired_pos, 0.01)
 	global_position += velocity * delta * 2#* (desired_pos - global_position).length()
-	#global_position = desired_pos #velocity * delta * (desired_pos - global_position).length()
-	#if Input.is_action_just_pressed("p1_look_lock"):
-	#	look_at(thrall.global_position + (thrall.global_basis.z * 10))
-	#cam.look_at(thrall.global_position + (Vector3.UP * 1.8))
 	player_look(delta)
-	
+
 
 func ray_cam_pos():
 	# Phys ray

--- a/scripts/camera_control.gd
+++ b/scripts/camera_control.gd
@@ -38,8 +38,8 @@ func _ready():
 	MgrPlayerSocket.get_player_one().mainCam = self
 
 # NOTE - _physics causes jitter, but _process causes a strange bug that looks at your feet on 144hz monitor
-func _physics_process(delta: float) -> void:
-
+#changed physics_process to _process, 
+func _process(delta: float) -> void:
 	if is_instance_valid(target_current) == false: # Guard clause style, baby!
 		return 
 	if freeze:
@@ -85,8 +85,9 @@ func _look(delta):
 	if target_curr != Vector3.ZERO:
 		_look_target_lock(delta)
 		return
-	target_curr = target_current.global_position
-	look_at(target_curr)
+	#remove:
+	#target_curr = target_current.global_position
+	look_at(target_current.global_position)
 	rotate(basis.x, deg_to_rad(31.5))
 
 func _look_target_lock(_delta):


### PR DESCRIPTION
cleaned up unwanted changes

Original PR comment:

updated _physics_process to just _process in both camera_control.gd and cam_gantry_playerFollow.gd.
also updated look(delta) function in camera_control.gd

These changes should cause the camera to persist its position as the player changes scenes and improve jittering as _physics_process runs at a fixed rate but _process runs at every frame.