### PR TITLE
Camera and mouse adjustments

### DIFF
--- a/scripts/UI/menu.gd
+++ b/scripts/UI/menu.gd
@@ -4,6 +4,8 @@ class_name Menu
 
 var parent_menu : Menu # Probably a button, but whoever it was needs to accept close_menu
 var child_menu : Menu
+var inEscape = 1
+
 
 ## This button will be back or quit if this is the root menu. 
 @export var close_button : Button 
@@ -11,6 +13,8 @@ var child_menu : Menu
 @export var focus_button : Button
 ## If set the open and close animations will be used
 @export var anim : AnimationPlayer
+
+
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
@@ -27,14 +31,21 @@ func _ready() -> void:
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(_delta: float) -> void:
+	var backButtonCalled = 0
 	if Input.is_action_just_pressed("ui_cancel"):
 		if is_instance_valid(parent_menu):
 			back_button()
+			backButtonCalled = 1
+	if is_instance_valid(parent_menu) and Input.mouse_mode == Input.MOUSE_MODE_CAPTURED:
+		if backButtonCalled == 1:
+			Input.mouse_mode = Input.MOUSE_MODE_VISIBLE
 
 
 func back_button():
+	print("Back pressed")
 	if is_instance_valid(parent_menu):
 		parent_menu.close_menu()
+		Input.mouse_mode = Input.MOUSE_MODE_CAPTURED
 	else:
 		get_tree().quit()
 
@@ -70,6 +81,8 @@ func focus():
 			if child is Button && child.visible == true && child.disabled == false:
 				child.grab_focus()
 				return
+
+
 
 
 func _anim_open():

--- a/scripts/cam_gantry_playerFollow.gd
+++ b/scripts/cam_gantry_playerFollow.gd
@@ -11,10 +11,13 @@ var velocity = Vector3.ZERO
 
 var look_rotation_vel = Vector2.ZERO
 var camLookAccell = 3.14
+var camTimer = 0.0
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	MgrPlayerSocket.get_player_one().ganty_thing = self
+	#this should keep mouse within boarders, need to capture escape button so user can interact with menu (to leave) 
+	Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
 
 
 #also changed _physics_process to process here for jitter fix
@@ -63,12 +66,22 @@ func player_look(delta):
 		#global_rotation_degrees.y = global_rotation_degrees.y #rotate_toward(original_rot_y, global_rotation_degrees.y, 50 * delta)
 		default_angle = -35
 	global_rotation_degrees.z = 0
-	global_rotation_degrees.x += (default_angle-global_rotation_degrees.x) * 0.9 * delta
+	#recentering here, add some timer so the rebound isn't immediate 
+	if disLook.length() != 0: #some kind of input 
+		camTimer = 0.6
+	else:
+		#subtraction should be proportional to framerate
+		#higher refresh rate would decrement the same as lower
+		camTimer -= delta
+	if camTimer <= 0:
+		global_rotation_degrees.x += (default_angle-global_rotation_degrees.x) * 0.9 * delta
 	
 
 
 func _input(event):
 	if event is InputEventMouseMotion:
+		#mouse movement will always reset timer
+		camTimer = 0.6
 		var disLook =  event.relative * 0.01
 		look_rotation_vel = disLook * 0.1 * camLookAccell
 		var default_angle = -20
@@ -83,4 +96,11 @@ func _input(event):
 			#global_rotation_degrees.y = global_rotation_degrees.y #rotate_toward(original_rot_y, global_rotation_degrees.y, 50 * delta)
 			default_angle = -35
 		global_rotation_degrees.z = 0
-		global_rotation_degrees.x += (default_angle-global_rotation_degrees.x) * 0.9 * 0.1
+		#global_rotation_degrees.x += (default_angle-global_rotation_degrees.x) * 0.9 * 0.1
+	#KEY_ESCAPE cant persist because user moves mouse in pause menu
+	#need a global to block MOUSE_MODE_CAPTURED
+	if event is InputEventKey:
+		if event.pressed and event.keycode == KEY_ESCAPE:
+			if Input.mouse_mode == Input.MOUSE_MODE_CAPTURED:
+				Input.mouse_mode = Input.MOUSE_MODE_VISIBLE
+	#for some reason this is true regardless:


### PR DESCRIPTION
# Mouse Capture
- Used Godot's Input class mouse function to set the mouse mode to either MOUSE_MODE_CAPTURED or MOUSE_MODE_VISIBLE depending on state
- The ready function in cam_gantry_playerFollow.gd hides the mouse when active
- Mouse only becomes visible in the pause menu when Escape is pressed
- Mouse visibility persists until the "Back" button is pressed

# Camera interpolation adjustment
- Added a timer that decrements by the delta of player_look() when the camera's position is changed
- Camera re-centers after timer is 0 (timer set to 0.6)