### PR TITLE
Movement package and poise break animation synchronization across network

### DIFF
--- a/art/Character/animator components/basic_move_stateMachine.tres
+++ b/art/Character/animator components/basic_move_stateMachine.tres
@@ -146,7 +146,6 @@ animation = &"jumps_and_falling/jump_standing"
 animation = &"walk_jog_run/land"
 
 [sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_upayn"]
-xfade_time = 1.0
 advance_mode = 2
 
 [sub_resource type="Curve" id="Curve_nosnc"]
@@ -279,4 +278,4 @@ states/walk_jog_run_jump_standing/position = Vector2(382, 276)
 states/walk_jog_run_land/node = SubResource("AnimationNodeAnimation_k7gio")
 states/walk_jog_run_land/position = Vector2(696, 329)
 transitions = ["Start", "walk_jog_run_idle", SubResource("AnimationNodeStateMachineTransition_upayn"), "walk_jog_run_idle", "MV blendtree", SubResource("AnimationNodeStateMachineTransition_6iyk2"), "MV blendtree", "walk_jog_run_idle", SubResource("AnimationNodeStateMachineTransition_6n3ai"), "walk_jog_run_idle", "aLib_actions_item_eat", SubResource("AnimationNodeStateMachineTransition_1ahjd"), "aLib_actions_item_eat", "walk_jog_run_idle", SubResource("AnimationNodeStateMachineTransition_x2yb8"), "walk_jog_run_idle", "aLib_actions_item_crush", SubResource("AnimationNodeStateMachineTransition_2650j"), "aLib_actions_item_crush", "walk_jog_run_idle", SubResource("AnimationNodeStateMachineTransition_urvxg"), "MV blendtree", "Sprint blendtree", SubResource("AnimationNodeStateMachineTransition_471fs"), "Sprint blendtree", "MV blendtree", SubResource("AnimationNodeStateMachineTransition_75a3i"), "walk_jog_run_idle", "sit down", SubResource("AnimationNodeStateMachineTransition_2vgh4"), "sit down", "sit_lounge_tscn", SubResource("AnimationNodeStateMachineTransition_b0hsq"), "sit_lounge_tscn", "stand up", SubResource("AnimationNodeStateMachineTransition_a3362"), "stand up", "walk_jog_run_idle", SubResource("AnimationNodeStateMachineTransition_edqvn"), "walk_jog_run_idle", "walk_jog_run_jump_standing", SubResource("AnimationNodeStateMachineTransition_k3l40"), "walk_jog_run_jump_standing", "MOVE", SubResource("AnimationNodeStateMachineTransition_ra883"), "walk_jog_run_idle", "MOVE", SubResource("AnimationNodeStateMachineTransition_cb13g"), "MOVE", "walk_jog_run_land", SubResource("AnimationNodeStateMachineTransition_0tvft"), "walk_jog_run_land", "walk_jog_run_idle", SubResource("AnimationNodeStateMachineTransition_o12w4"), "MV blendtree", "MOVE", SubResource("AnimationNodeStateMachineTransition_nosnc"), "MV blendtree", "walk_jog_run_jump_standing", SubResource("AnimationNodeStateMachineTransition_k4lno"), "Sprint blendtree", "MOVE", SubResource("AnimationNodeStateMachineTransition_6nkpm"), "Sprint blendtree", "walk_jog_run_jump_standing", SubResource("AnimationNodeStateMachineTransition_cwjg4")]
-graph_offset = Vector2(-7, 112)
+graph_offset = Vector2(-296, -30)

--- a/art/Character/animator components/claymore_moveset.tres
+++ b/art/Character/animator components/claymore_moveset.tres
@@ -113,11 +113,6 @@ animation = &"aLib_combat_sword/combat_poisebreak_idle"
 [sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_q134k"]
 animation = &"aLib_combat_sword/combat_poisebreak"
 play_mode = 1
-use_custom_timeline = true
-timeline_length = 4.0
-stretch_time_scale = true
-start_offset = 0.0
-loop_mode = 0
 
 [sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_gip2f"]
 animation = &"aLib_combat_sword/combat_poisebreak"
@@ -581,7 +576,7 @@ advance_mode = 2
 
 [sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_1sv8d"]
 advance_mode = 2
-advance_expression = "character.poise_current <= 0"
+advance_expression = "action_q_check(\"poise_break\")"
 
 [sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_pfdlv"]
 switch_mode = 2
@@ -590,7 +585,7 @@ advance_mode = 2
 [sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_5flc5"]
 break_loop_at_end = true
 advance_mode = 2
-advance_expression = "character.poise_current >= 0 && character.stamina_current >= 0"
+advance_expression = "action_q_check(\"poise_break\") == false"
 
 [sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_adr5q"]
 switch_mode = 2
@@ -741,11 +736,11 @@ states/walk_airborne/position = Vector2(192.5, -464.25)
 states/walk_land/node = SubResource("AnimationNodeAnimation_qgdka")
 states/walk_land/position = Vector2(362.07, -464.5)
 transitions = ["standing", "crouching", SubResource("AnimationNodeStateMachineTransition_0on8m"), "airborne", "air_A_L", SubResource("AnimationNodeStateMachineTransition_y20av"), "airborne", "air_A_H", SubResource("AnimationNodeStateMachineTransition_3acqo"), "airborne", "air_A_P", SubResource("AnimationNodeStateMachineTransition_c2nfx"), "standing", "offhand_A_L", SubResource("AnimationNodeStateMachineTransition_vdfbe"), "standing", "norm_A_L", SubResource("AnimationNodeStateMachineTransition_m5f2g"), "standing", "norm_A_H", SubResource("AnimationNodeStateMachineTransition_tkxwo"), "standing", "norm_A_P", SubResource("AnimationNodeStateMachineTransition_twegj"), "standing", "sprint_A_L", SubResource("AnimationNodeStateMachineTransition_37iui"), "standing", "sprint_A_H", SubResource("AnimationNodeStateMachineTransition_6cq6x"), "standing", "sprint_A_P", SubResource("AnimationNodeStateMachineTransition_hha6t"), "crouching", "crouch_A_L", SubResource("AnimationNodeStateMachineTransition_31ohk"), "crouching", "crouch_A_P", SubResource("AnimationNodeStateMachineTransition_rwkfb"), "crouching", "sprint_A_L", SubResource("AnimationNodeStateMachineTransition_lmkc5"), "crouching", "sprint_A_H", SubResource("AnimationNodeStateMachineTransition_wjw4k"), "crouching", "sprint_A_P", SubResource("AnimationNodeStateMachineTransition_sqt8b"), "standing", "WepArt", SubResource("AnimationNodeStateMachineTransition_hxyew"), "Start", "airborne", SubResource("AnimationNodeStateMachineTransition_niclv"), "Start", "crouching", SubResource("AnimationNodeStateMachineTransition_1byen"), "crouching", "standing", SubResource("AnimationNodeStateMachineTransition_meysa"), "offhand_A_L", "standing", SubResource("AnimationNodeStateMachineTransition_4vpok"), "norm_A_L", "standing", SubResource("AnimationNodeStateMachineTransition_fq0gl"), "norm_A_H", "standing", SubResource("AnimationNodeStateMachineTransition_3efym"), "norm_A_P", "standing", SubResource("AnimationNodeStateMachineTransition_61xe6"), "sprint_A_P", "standing", SubResource("AnimationNodeStateMachineTransition_2s0d8"), "sprint_A_H", "standing", SubResource("AnimationNodeStateMachineTransition_6cxn7"), "sprint_A_L", "standing", SubResource("AnimationNodeStateMachineTransition_i4usc"), "crouch_A_L", "standing", SubResource("AnimationNodeStateMachineTransition_6k2y4"), "crouch_A_P", "standing", SubResource("AnimationNodeStateMachineTransition_kadue"), "WepArt", "standing", SubResource("AnimationNodeStateMachineTransition_xfh0m"), "air_A_L", "standing", SubResource("AnimationNodeStateMachineTransition_6mykl"), "air_A_H", "standing", SubResource("AnimationNodeStateMachineTransition_7dakr"), "air_A_P", "standing", SubResource("AnimationNodeStateMachineTransition_8fb84"), "dodge_A_L", "standing", SubResource("AnimationNodeStateMachineTransition_2mr6w"), "dodge_A_P", "standing", SubResource("AnimationNodeStateMachineTransition_uv0un"), "back_A_L", "standing", SubResource("AnimationNodeStateMachineTransition_pnmrd"), "back_A_P", "standing", SubResource("AnimationNodeStateMachineTransition_n2rc7"), "standing", "backstep", SubResource("AnimationNodeStateMachineTransition_57g6n"), "standing", "dodge", SubResource("AnimationNodeStateMachineTransition_v5kr3"), "dodge", "dodge_A_L", SubResource("AnimationNodeStateMachineTransition_kjabd"), "dodge", "dodge_A_P", SubResource("AnimationNodeStateMachineTransition_qpy6c"), "backstep", "back_A_L", SubResource("AnimationNodeStateMachineTransition_1rr7x"), "backstep", "back_A_P", SubResource("AnimationNodeStateMachineTransition_b3rwd"), "dodge", "standing", SubResource("AnimationNodeStateMachineTransition_b7cpc"), "backstep", "standing", SubResource("AnimationNodeStateMachineTransition_8xyly"), "standing", "jmp", SubResource("AnimationNodeStateMachineTransition_cokce"), "jmp", "airborne", SubResource("AnimationNodeStateMachineTransition_fnaal"), "walk_airborne", "standing", SubResource("AnimationNodeStateMachineTransition_6tydq"), "standing", "walk_airborne", SubResource("AnimationNodeStateMachineTransition_s7hbm"), "walk_airborne", "airborne", SubResource("AnimationNodeStateMachineTransition_7bn3p"), "crouching", "norm_A_H", SubResource("AnimationNodeStateMachineTransition_yx40u"), "airborne", "walk_land", SubResource("AnimationNodeStateMachineTransition_ufax3"), "walk_land", "standing", SubResource("AnimationNodeStateMachineTransition_pp6kn"), "norm_A_L", "norm_A_L_2", SubResource("AnimationNodeStateMachineTransition_7clbw"), "norm_A_L_2", "norm_A_L", SubResource("AnimationNodeStateMachineTransition_2y3xv"), "norm_A_L_2", "standing", SubResource("AnimationNodeStateMachineTransition_hxwq1"), "standing", "poisebreak", SubResource("AnimationNodeStateMachineTransition_1sv8d"), "poisebreak", "pb_idle", SubResource("AnimationNodeStateMachineTransition_pfdlv"), "pb_idle", "pb_stand", SubResource("AnimationNodeStateMachineTransition_5flc5"), "pb_stand", "standing", SubResource("AnimationNodeStateMachineTransition_adr5q"), "dodge", "dodge_2", SubResource("AnimationNodeStateMachineTransition_4wevg"), "dodge_2", "dodge", SubResource("AnimationNodeStateMachineTransition_rt65g"), "dodge_2", "dodge_A_L", SubResource("AnimationNodeStateMachineTransition_6jcvu"), "dodge_2", "dodge_A_P", SubResource("AnimationNodeStateMachineTransition_jh62r"), "dodge_2", "standing", SubResource("AnimationNodeStateMachineTransition_mpm0r"), "standing", "block_hit", SubResource("AnimationNodeStateMachineTransition_ekfu4"), "block_hit", "standing", SubResource("AnimationNodeStateMachineTransition_jtwav"), "draw_sword", "airborne", SubResource("AnimationNodeStateMachineTransition_so2rg"), "draw_sword", "standing", SubResource("AnimationNodeStateMachineTransition_2br3u"), "Start", "draw_sword", SubResource("AnimationNodeStateMachineTransition_o4l0g"), "standing", "scheathe", SubResource("AnimationNodeStateMachineTransition_dw7eo")]
-graph_offset = Vector2(177, -127)
+graph_offset = Vector2(-265, 79)
 
 [resource]
 resource_name = "claymore moveset"
-graph_offset = Vector2(-135, 111)
+graph_offset = Vector2(-54, 254)
 nodes/output/position = Vector2(560, 250)
 "nodes/Attack Tree/node" = SubResource("AnimationNodeStateMachine_1wdgk")
 "nodes/Attack Tree/position" = Vector2(300, 240)

--- a/art/Character/animator components/oneHand_moveset.tres
+++ b/art/Character/animator components/oneHand_moveset.tres
@@ -1,4 +1,4 @@
-[gd_resource type="AnimationNodeBlendTree" load_steps=141 format=3 uid="uid://dxputd8clfanr"]
+[gd_resource type="AnimationNodeBlendTree" load_steps=144 format=3 uid="uid://dxputd8clfanr"]
 
 [ext_resource type="AnimationNodeBlendTree" uid="uid://10yh2iq5uoji" path="res://art/Character/animator components/small_components/sm_movementTree_basic.tres" id="2_lfsq2"]
 [ext_resource type="Curve" uid="uid://brijpnu58w121" path="res://art/Character/animator components/small_components/curve_minorOvershoot.tres" id="3_b2n5l"]
@@ -110,11 +110,6 @@ animation = &"aLib_combat_sword/combat_poisebreak_idle"
 [sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_q134k"]
 animation = &"aLib_combat_sword/combat_poisebreak"
 play_mode = 1
-use_custom_timeline = true
-timeline_length = 4.0
-stretch_time_scale = true
-start_offset = 0.0
-loop_mode = 0
 
 [sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_gip2f"]
 animation = &"aLib_combat_sword/combat_poisebreak"
@@ -217,7 +212,6 @@ switch_mode = 2
 advance_mode = 2
 
 [sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_4lcdk"]
-xfade_time = 0.1
 advance_mode = 2
 advance_expression = "action_q_check(\"block\")
 "
@@ -241,16 +235,29 @@ advance_mode = 2
 advance_expression = "hand_state == HandState.ONE_HAND"
 
 [sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_gutr1"]
-xfade_time = 0.1
 advance_mode = 2
 advance_expression = "action_q_check(\"block\")
 "
 
 [sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_hhgqv"]
-xfade_time = 0.1
 advance_mode = 2
 advance_expression = "action_q_check(\"block\")
 "
+
+[sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_fs6sb"]
+xfade_time = 0.1
+advance_mode = 2
+advance_expression = "action_q_check(\"block\") == false"
+
+[sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_ocg0t"]
+xfade_time = 0.1
+advance_mode = 2
+advance_expression = "action_q_check(\"block\") == false"
+
+[sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_lfsq2"]
+xfade_time = 0.1
+advance_mode = 2
+advance_expression = "action_q_check(\"block\") == false"
 
 [sub_resource type="AnimationNodeStateMachine" id="AnimationNodeStateMachine_fs6sb"]
 states/1h/node = SubResource("AnimationNodeAnimation_ky3yf")
@@ -266,8 +273,8 @@ states/unarmed/node = SubResource("AnimationNodeAnimation_vefrs")
 states/unarmed/position = Vector2(467.5, 101.5)
 states/unblock/node = SubResource("AnimationNodeAnimation_ppgm1")
 states/unblock/position = Vector2(798, 280)
-transitions = ["1h", "2h", SubResource("AnimationNodeStateMachineTransition_iw2yf"), "2h", "1h", SubResource("AnimationNodeStateMachineTransition_hjmlm"), "Start", "1h", SubResource("AnimationNodeStateMachineTransition_k4x24"), "Start", "2h", SubResource("AnimationNodeStateMachineTransition_2tcnc"), "Start", "unarmed", SubResource("AnimationNodeStateMachineTransition_j4y57"), "unarmed", "1h", SubResource("AnimationNodeStateMachineTransition_ucqpo"), "unarmed", "2h", SubResource("AnimationNodeStateMachineTransition_jel8e"), "2h", "unarmed", SubResource("AnimationNodeStateMachineTransition_6sbcu"), "1h", "unarmed", SubResource("AnimationNodeStateMachineTransition_dutrb"), "blocking", "unblock", SubResource("AnimationNodeStateMachineTransition_ssfuj"), "block", "blocking", SubResource("AnimationNodeStateMachineTransition_wap3k"), "2h", "block", SubResource("AnimationNodeStateMachineTransition_4lcdk"), "unblock", "2h", SubResource("AnimationNodeStateMachineTransition_eeqv6"), "unblock", "unarmed", SubResource("AnimationNodeStateMachineTransition_a1d6e"), "unblock", "1h", SubResource("AnimationNodeStateMachineTransition_ygige"), "1h", "block", SubResource("AnimationNodeStateMachineTransition_gutr1"), "unarmed", "block", SubResource("AnimationNodeStateMachineTransition_hhgqv")]
-graph_offset = Vector2(124, -106)
+transitions = ["1h", "2h", SubResource("AnimationNodeStateMachineTransition_iw2yf"), "2h", "1h", SubResource("AnimationNodeStateMachineTransition_hjmlm"), "Start", "1h", SubResource("AnimationNodeStateMachineTransition_k4x24"), "Start", "2h", SubResource("AnimationNodeStateMachineTransition_2tcnc"), "Start", "unarmed", SubResource("AnimationNodeStateMachineTransition_j4y57"), "unarmed", "1h", SubResource("AnimationNodeStateMachineTransition_ucqpo"), "unarmed", "2h", SubResource("AnimationNodeStateMachineTransition_jel8e"), "2h", "unarmed", SubResource("AnimationNodeStateMachineTransition_6sbcu"), "1h", "unarmed", SubResource("AnimationNodeStateMachineTransition_dutrb"), "blocking", "unblock", SubResource("AnimationNodeStateMachineTransition_ssfuj"), "block", "blocking", SubResource("AnimationNodeStateMachineTransition_wap3k"), "2h", "block", SubResource("AnimationNodeStateMachineTransition_4lcdk"), "unblock", "2h", SubResource("AnimationNodeStateMachineTransition_eeqv6"), "unblock", "unarmed", SubResource("AnimationNodeStateMachineTransition_a1d6e"), "unblock", "1h", SubResource("AnimationNodeStateMachineTransition_ygige"), "1h", "block", SubResource("AnimationNodeStateMachineTransition_gutr1"), "unarmed", "block", SubResource("AnimationNodeStateMachineTransition_hhgqv"), "block", "2h", SubResource("AnimationNodeStateMachineTransition_fs6sb"), "block", "unarmed", SubResource("AnimationNodeStateMachineTransition_ocg0t"), "block", "1h", SubResource("AnimationNodeStateMachineTransition_lfsq2")]
+graph_offset = Vector2(195, -116)
 
 [sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_i8rc0"]
 filter_enabled = true
@@ -278,7 +285,7 @@ filter_enabled = true
 filters = ["char/Skeleton3D:chest", "char/Skeleton3D:f_index.01.L", "char/Skeleton3D:f_index.01.R", "char/Skeleton3D:f_index.02.L", "char/Skeleton3D:f_index.02.R", "char/Skeleton3D:f_index.03.L", "char/Skeleton3D:f_index.03.R", "char/Skeleton3D:f_middle.01.L", "char/Skeleton3D:f_middle.01.R", "char/Skeleton3D:f_middle.02.L", "char/Skeleton3D:f_middle.02.R", "char/Skeleton3D:f_middle.03.L", "char/Skeleton3D:f_middle.03.R", "char/Skeleton3D:f_pinky.01.L", "char/Skeleton3D:f_pinky.01.R", "char/Skeleton3D:f_pinky.02.L", "char/Skeleton3D:f_pinky.02.R", "char/Skeleton3D:f_pinky.03.L", "char/Skeleton3D:f_pinky.03.R", "char/Skeleton3D:f_ring.01.L", "char/Skeleton3D:f_ring.01.R", "char/Skeleton3D:f_ring.02.L", "char/Skeleton3D:f_ring.02.R", "char/Skeleton3D:f_ring.03.L", "char/Skeleton3D:f_ring.03.R", "char/Skeleton3D:forearm.L", "char/Skeleton3D:forearm.R", "char/Skeleton3D:hand.L", "char/Skeleton3D:hand.R", "char/Skeleton3D:head", "char/Skeleton3D:jaw", "char/Skeleton3D:neck", "char/Skeleton3D:palm.01.L", "char/Skeleton3D:palm.01.R", "char/Skeleton3D:palm.02.L", "char/Skeleton3D:palm.02.R", "char/Skeleton3D:palm.03.L", "char/Skeleton3D:palm.03.R", "char/Skeleton3D:palm.04.L", "char/Skeleton3D:palm.04.R", "char/Skeleton3D:prop.R", "char/Skeleton3D:shoulder.L", "char/Skeleton3D:shoulder.R", "char/Skeleton3D:spine", "char/Skeleton3D:thumb.01.L", "char/Skeleton3D:thumb.01.R", "char/Skeleton3D:thumb.02.L", "char/Skeleton3D:thumb.02.R", "char/Skeleton3D:thumb.03.L", "char/Skeleton3D:thumb.03.R", "char/Skeleton3D:upper_arm.L", "char/Skeleton3D:upper_arm.R"]
 
 [sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_5y5bp"]
-graph_offset = Vector2(-511.1537, -56.166763)
+graph_offset = Vector2(-509.1537, 6.8332367)
 nodes/Animation/node = SubResource("AnimationNodeAnimation_fyoge")
 nodes/Animation/position = Vector2(-280, 380)
 "nodes/Handedness Idles/node" = SubResource("AnimationNodeStateMachine_fs6sb")
@@ -573,7 +580,7 @@ advance_mode = 2
 
 [sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_1sv8d"]
 advance_mode = 2
-advance_expression = "character.poise_current <= 0"
+advance_expression = "action_q_check(\"poise_break\")"
 
 [sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_pfdlv"]
 switch_mode = 2
@@ -582,9 +589,10 @@ advance_mode = 2
 [sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_5flc5"]
 break_loop_at_end = true
 advance_mode = 2
-advance_expression = "character.poise_current >= 0 && character.stamina_current >= 0"
+advance_expression = "action_q_check(\"poise_break\") == false"
 
 [sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_adr5q"]
+xfade_time = 0.15
 switch_mode = 2
 advance_mode = 2
 
@@ -707,11 +715,11 @@ states/walk_airborne/position = Vector2(192.5, -464.25)
 states/walk_land/node = SubResource("AnimationNodeAnimation_qgdka")
 states/walk_land/position = Vector2(362.07, -464.5)
 transitions = ["standing", "crouching", SubResource("AnimationNodeStateMachineTransition_0on8m"), "airborne", "air_A_L", SubResource("AnimationNodeStateMachineTransition_y20av"), "airborne", "air_A_H", SubResource("AnimationNodeStateMachineTransition_3acqo"), "airborne", "air_A_P", SubResource("AnimationNodeStateMachineTransition_c2nfx"), "standing", "offhand_A_L", SubResource("AnimationNodeStateMachineTransition_vdfbe"), "standing", "norm_A_L", SubResource("AnimationNodeStateMachineTransition_m5f2g"), "standing", "norm_A_H", SubResource("AnimationNodeStateMachineTransition_tkxwo"), "standing", "norm_A_P", SubResource("AnimationNodeStateMachineTransition_twegj"), "standing", "sprint_A_L", SubResource("AnimationNodeStateMachineTransition_37iui"), "standing", "sprint_A_H", SubResource("AnimationNodeStateMachineTransition_6cq6x"), "standing", "sprint_A_P", SubResource("AnimationNodeStateMachineTransition_hha6t"), "crouching", "crouch_A_L", SubResource("AnimationNodeStateMachineTransition_31ohk"), "crouching", "crouch_A_P", SubResource("AnimationNodeStateMachineTransition_rwkfb"), "crouching", "sprint_A_L", SubResource("AnimationNodeStateMachineTransition_lmkc5"), "crouching", "sprint_A_H", SubResource("AnimationNodeStateMachineTransition_wjw4k"), "crouching", "sprint_A_P", SubResource("AnimationNodeStateMachineTransition_sqt8b"), "standing", "WepArt", SubResource("AnimationNodeStateMachineTransition_hxyew"), "Start", "standing", SubResource("AnimationNodeStateMachineTransition_mvuby"), "Start", "airborne", SubResource("AnimationNodeStateMachineTransition_niclv"), "Start", "crouching", SubResource("AnimationNodeStateMachineTransition_1byen"), "crouching", "standing", SubResource("AnimationNodeStateMachineTransition_meysa"), "offhand_A_L", "standing", SubResource("AnimationNodeStateMachineTransition_4vpok"), "norm_A_L", "standing", SubResource("AnimationNodeStateMachineTransition_fq0gl"), "norm_A_H", "standing", SubResource("AnimationNodeStateMachineTransition_3efym"), "norm_A_P", "standing", SubResource("AnimationNodeStateMachineTransition_61xe6"), "sprint_A_P", "standing", SubResource("AnimationNodeStateMachineTransition_2s0d8"), "sprint_A_H", "standing", SubResource("AnimationNodeStateMachineTransition_6cxn7"), "sprint_A_L", "standing", SubResource("AnimationNodeStateMachineTransition_i4usc"), "crouch_A_L", "standing", SubResource("AnimationNodeStateMachineTransition_6k2y4"), "crouch_A_P", "standing", SubResource("AnimationNodeStateMachineTransition_kadue"), "WepArt", "standing", SubResource("AnimationNodeStateMachineTransition_xfh0m"), "air_A_L", "standing", SubResource("AnimationNodeStateMachineTransition_6mykl"), "air_A_H", "standing", SubResource("AnimationNodeStateMachineTransition_7dakr"), "air_A_P", "standing", SubResource("AnimationNodeStateMachineTransition_8fb84"), "dodge_A_L", "standing", SubResource("AnimationNodeStateMachineTransition_2mr6w"), "dodge_A_P", "standing", SubResource("AnimationNodeStateMachineTransition_uv0un"), "back_A_L", "standing", SubResource("AnimationNodeStateMachineTransition_pnmrd"), "back_A_P", "standing", SubResource("AnimationNodeStateMachineTransition_n2rc7"), "standing", "backstep", SubResource("AnimationNodeStateMachineTransition_57g6n"), "standing", "dodge", SubResource("AnimationNodeStateMachineTransition_v5kr3"), "dodge", "dodge_A_L", SubResource("AnimationNodeStateMachineTransition_kjabd"), "dodge", "dodge_A_P", SubResource("AnimationNodeStateMachineTransition_qpy6c"), "backstep", "back_A_L", SubResource("AnimationNodeStateMachineTransition_1rr7x"), "backstep", "back_A_P", SubResource("AnimationNodeStateMachineTransition_b3rwd"), "dodge", "standing", SubResource("AnimationNodeStateMachineTransition_b7cpc"), "backstep", "standing", SubResource("AnimationNodeStateMachineTransition_8xyly"), "standing", "jmp", SubResource("AnimationNodeStateMachineTransition_cokce"), "jmp", "airborne", SubResource("AnimationNodeStateMachineTransition_fnaal"), "walk_airborne", "standing", SubResource("AnimationNodeStateMachineTransition_6tydq"), "standing", "walk_airborne", SubResource("AnimationNodeStateMachineTransition_s7hbm"), "walk_airborne", "airborne", SubResource("AnimationNodeStateMachineTransition_7bn3p"), "crouching", "norm_A_H", SubResource("AnimationNodeStateMachineTransition_yx40u"), "airborne", "walk_land", SubResource("AnimationNodeStateMachineTransition_ufax3"), "walk_land", "standing", SubResource("AnimationNodeStateMachineTransition_pp6kn"), "norm_A_L", "norm_A_L_2", SubResource("AnimationNodeStateMachineTransition_7clbw"), "norm_A_L_2", "norm_A_L", SubResource("AnimationNodeStateMachineTransition_2y3xv"), "norm_A_L_2", "standing", SubResource("AnimationNodeStateMachineTransition_hxwq1"), "standing", "poisebreak", SubResource("AnimationNodeStateMachineTransition_1sv8d"), "poisebreak", "pb_idle", SubResource("AnimationNodeStateMachineTransition_pfdlv"), "pb_idle", "pb_stand", SubResource("AnimationNodeStateMachineTransition_5flc5"), "pb_stand", "standing", SubResource("AnimationNodeStateMachineTransition_adr5q"), "dodge", "dodge_2", SubResource("AnimationNodeStateMachineTransition_4wevg"), "dodge_2", "dodge", SubResource("AnimationNodeStateMachineTransition_rt65g"), "dodge_2", "dodge_A_L", SubResource("AnimationNodeStateMachineTransition_6jcvu"), "dodge_2", "dodge_A_P", SubResource("AnimationNodeStateMachineTransition_jh62r"), "dodge_2", "standing", SubResource("AnimationNodeStateMachineTransition_mpm0r"), "standing", "block_hit", SubResource("AnimationNodeStateMachineTransition_ekfu4"), "block_hit", "standing", SubResource("AnimationNodeStateMachineTransition_jtwav")]
-graph_offset = Vector2(-138, -57)
+graph_offset = Vector2(-375, 17)
 
 [resource]
 resource_name = "oneHand moveset"
-graph_offset = Vector2(-91, 7.272705)
+graph_offset = Vector2(10, 187)
 nodes/output/position = Vector2(560, 250)
 "nodes/Attack Tree/node" = SubResource("AnimationNodeStateMachine_1wdgk")
 "nodes/Attack Tree/position" = Vector2(300, 240)

--- a/scripts/actor.gd
+++ b/scripts/actor.gd
@@ -157,7 +157,7 @@ func _physics_process(_delta):
 
 	move_and_slide()
 	if is_multiplayer_authority():
-		net_sync.rpc(desired_move, rotation, position, sprint, character.health_current, character.poise_current, character.poise_regen_timer, hand_state)
+		net_sync.rpc(desired_move, rotation, position, sprint, character.health_current, hand_state, current_moveset)
 	return
 
 
@@ -217,6 +217,7 @@ func movement_package_checks():
 			#		return
 			#else:
 			current_moveset = x
+			
 			state_machine.travel(movement_sets[current_moveset].name)
 			if is_multiplayer_authority():
 				net_anim_pack_change.rpc(current_moveset)
@@ -333,6 +334,8 @@ func take_damage(damage_data : Dictionary, id : int) -> Armament.AttackState:
 			character.health_current -= damage
 		character.poise_current -= 5
 		if character.poise_current <= 0:
+			if "poise_break" not in action_q.keys():
+				enque_action("poise_break", 1500) # stop double falling
 			character.poise_regen_timer = 0.5
 		else:
 			character.poise_regen_timer = character.poise_regen_delay
@@ -413,11 +416,11 @@ func cb(msg : String):
 # NOTE - Action queue system. Things are put on and have a short 
 # buffer time after which they are knocked off. I am not sure if this
 # is a good approach, but I'm trying it out
-const ACTION_Q_BUFFER_TIME = 200.0 #milliseconds
-var action_q = {}
+const ACTION_Q_BUFFER_TIME = 33 #milliseconds, about 2 frames at 60
+var action_q : Dictionary[String, int] = {}
 
-func enque_action(action : String):
-	action_q[action] = Time.get_ticks_msec() + (ACTION_Q_BUFFER_TIME)
+func enque_action(action : String, duration : int = ACTION_Q_BUFFER_TIME):
+	action_q[action] = Time.get_ticks_msec() + (duration)
 	if "attack" in action:
 		combat_mode = true
 		combat_relax_timer = 5.0
@@ -434,19 +437,15 @@ func action_q_check(action : String, consume=false) -> bool:
 	if action_q.size() == 0:
 		return false
 	if action in action_q.keys():
+		if is_multiplayer_authority():
+			_action_q_net.rpc(action, (action_q[action]) - Time.get_ticks_msec())
 		if consume == true:
 			action_q.erase(action)
-		if is_multiplayer_authority():
-			_action_q_net.rpc(action, current_moveset)
 		return true
 	return false
 
 @rpc
-func _action_q_net(act : String, current_pack : int):
-	if current_moveset != current_pack:
-		current_moveset = current_pack
-		var state_machine = animation_tree["parameters/playback"]
-		state_machine.travel(movement_sets[current_moveset].name)
+func _action_q_net(act : String, _remaining_duration : int):
 	enque_action(act)
 # !SECTION - End action_q system
 
@@ -591,7 +590,7 @@ func rpc_mp_spawn(player_type : String, anim : int):
 
 
 @rpc("unreliable")
-func net_sync(d_move : Vector3, c_rotation : Vector3, c_position : Vector3, c_sprint : bool, c_health, c_poise, c_p_regen, c_hand_state : int):
+func net_sync(d_move : Vector3, c_rotation : Vector3, c_position : Vector3, c_sprint : bool, c_health, c_hand_state : int, c_mvpk):
 	if is_multiplayer_authority():
 		return
 	#print(str(multiplayer.get_unique_id()) + "| Update for " + str(multiplayer.get_remote_sender_id()) +" for " + name)
@@ -600,9 +599,11 @@ func net_sync(d_move : Vector3, c_rotation : Vector3, c_position : Vector3, c_sp
 	position = c_position
 	sprint = c_sprint
 	character.health_current = c_health
-	character.poise_current = c_poise
-	character.poise_regen_timer = c_p_regen
 	hand_state = c_hand_state as HandState
+	if c_mvpk != current_moveset:
+		current_moveset = c_mvpk
+		var state_machine = animation_tree["parameters/playback"]
+		state_machine.travel(movement_sets[current_moveset].name)
 
 
 func _on_accessory_changed():

--- a/scripts/actor.gd
+++ b/scripts/actor.gd
@@ -157,7 +157,7 @@ func _physics_process(_delta):
 
 	move_and_slide()
 	if is_multiplayer_authority():
-		net_sync.rpc(desired_move, rotation, position, sprint, character.health_current, hand_state)
+		net_sync.rpc(desired_move, rotation, position, sprint, character.health_current, character.poise_current, character.poise_regen_timer, hand_state)
 	return
 
 
@@ -217,7 +217,6 @@ func movement_package_checks():
 			#		return
 			#else:
 			current_moveset = x
-			
 			state_machine.travel(movement_sets[current_moveset].name)
 			if is_multiplayer_authority():
 				net_anim_pack_change.rpc(current_moveset)
@@ -446,6 +445,8 @@ func action_q_check(action : String, consume=false) -> bool:
 func _action_q_net(act : String, current_pack : int):
 	if current_moveset != current_pack:
 		current_moveset = current_pack
+		var state_machine = animation_tree["parameters/playback"]
+		state_machine.travel(movement_sets[current_moveset].name)
 	enque_action(act)
 # !SECTION - End action_q system
 
@@ -590,7 +591,7 @@ func rpc_mp_spawn(player_type : String, anim : int):
 
 
 @rpc("unreliable")
-func net_sync(d_move : Vector3, c_rotation : Vector3, c_position : Vector3, c_sprint : bool, c_health, c_hand_state : int):
+func net_sync(d_move : Vector3, c_rotation : Vector3, c_position : Vector3, c_sprint : bool, c_health, c_poise, c_p_regen, c_hand_state : int):
 	if is_multiplayer_authority():
 		return
 	#print(str(multiplayer.get_unique_id()) + "| Update for " + str(multiplayer.get_remote_sender_id()) +" for " + name)
@@ -599,6 +600,8 @@ func net_sync(d_move : Vector3, c_rotation : Vector3, c_position : Vector3, c_sp
 	position = c_position
 	sprint = c_sprint
 	character.health_current = c_health
+	character.poise_current = c_poise
+	character.poise_regen_timer = c_p_regen
 	hand_state = c_hand_state as HandState
 
 


### PR DESCRIPTION
- The net_sync function within actor.gd now sends the current movement package, and switches to it when appropriate. 
- The poise break animation is now caused by the "poise_break" action in the action_q within actor.gd. This successfully decouples the animation tree from local character state. 
- The action Q system had it's default time changed from 200ms to 33ms (two frames at 60), and allows a custom duration to be set for the effect.
For example: the poise_break lasts 1.5 seconds now. 
- The net_sync function now sends the remaining duration with the action_q data, so events meant to last longer (poise_break) do so, but also expire properly. 
- Action_q is now a typed dictionary. Not sure if this is important but it may have it be slightly faster.